### PR TITLE
Add support for custom YAML export options

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -21,6 +21,7 @@ module.exports = class Mdify {
      *
      *  - `start` (String): The start delimiter of the metadata (default: `---`).
      *  - `end` (String): The end delimiter of the metadata (default: `---`).
+     *  - `yamlOptions` (Object): Custom ys-yaml options.
      *
      * @returns {String} The markdown content prefixed by the stringified metadata.
      */
@@ -29,6 +30,7 @@ module.exports = class Mdify {
         options = ul.merge({
             start: "---"
           , end: "---"
+          , yamlOptions: {}
         });
 
         if (typeof metadata === "string") {
@@ -37,7 +39,7 @@ module.exports = class Mdify {
         }
 
         if (metadata) {
-            metadata = yaml.safeDump(metadata);
+            metadata = yaml.safeDump(metadata, options.yamlOptions);
         }
 
         return options.start + "\n"


### PR DESCRIPTION
Allows custom options to be passed directly to yaml.safeDump(). Required to refine the export style (e.g. generating the canonical form of null).