### PR TITLE
Fix Docs (Types, JSDoc) and Parameters

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -28,11 +28,7 @@ Parses the markdown input and the metadata.
  - `converterOptions` (Object): The converter options passed to [`showdown`](https://github.com/showdownjs/showdown).
 
 #### Return
-- **Object** An object containing the following fields:
- - `markdown` (String): The markdown content.
- - `metadata` (Object): The parsed metadata.
- - `rawMeta` (String): The raw metadata content.
- - `html` (String): The generated HTML from markdown.
+- [**ParseResult**][type-parseresult]
 
 ### `writeFile(path, metadata, content[, options[, cb]])`
 Writes the generated content into a file.
@@ -53,9 +49,16 @@ Parses a markdown file.
 - **Function** `[cb]`: The callback function.
 
 #### Return
-- **Object** **If `cb` was omitted**: an object containing the following fields:
- - `markdown` (String): The markdown content.
- - `metadata` (Object): The parsed metadata.
- - `rawMeta` (String): The raw metadata content.
- - `html` (String): The generated HTML from markdown.
+- [**ParseResult**][type-parseresult] Only **if `cb` was omitted**.
 
+---
+
+### Type: `ParseResult`
+An object containing the following fields:
+
+- **String** `markdown`: The Markdown content.
+- **Object** `metadata`: The parsed metadata.
+- **String** `rawMeta`: The raw metadata content.
+- **String** `html`: The generated HTML from Markdown.
+
+[type-parseresult]: #type-parseresult

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -2,14 +2,13 @@
 
 You can see below the API reference of this module.
 
-### `stringify(metadata, content, opts)`
+### `stringify(metadata, content[, options])`
 Stringify metadata and content.
 
 #### Params
-
 - **Object** `metadata`: The metadata object.
 - **String** `content`: The markdown content.
-- **Object** `opts`: An object containing the following fields:
+- **Object** `[options]`: An object containing the following fields:
  - `start` (String): The start delimiter of the metadata (default: `---`).
  - `end` (String): The end delimiter of the metadata (default: `---`).
  - `yamlOptions` (Object): Custom js-yaml options.
@@ -17,13 +16,12 @@ Stringify metadata and content.
 #### Return
 - **String** The markdown content prefixed by the stringified metadata.
 
-### `parse(input, opts)`
+### `parse(input[, options])`
 Parses the markdown input and the metadata.
 
 #### Params
-
 - **String** `input`: The markdown code. If it contains metadata, it will be parsed.
-- **Object** `opts`: An object containing the following fields:
+- **Object** `[options]`: An object containing the following fields:
  - `start` (String): The metadata prefix (default: `---`).
  - `end` (RegExp): The metadata end.
  - `html` (Boolean): If `true`, the markdown code will be parsed into HTML (default: `true`).
@@ -36,23 +34,28 @@ Parses the markdown input and the metadata.
  - `rawMeta` (String): The raw metadata content.
  - `html` (String): The generated HTML from markdown.
 
-### `writeFile(path, metadata, content, options, cb)`
+### `writeFile(path, metadata, content[, options[, cb]])`
 Writes the generated content into a file.
 
 #### Params
-
 - **String** `path`: The file path.
 - **Object** `metadata`: The metadata object.
 - **String** `content`: The markdown content.
-- **Object** `options`: The stringify options.
-- **Function** `cb`: The callback function.
+- **Object** `[options]`: The stringify options.
+- **Function** `[cb]`: The callback function.
 
-### `parseFile(path, opts, cb)`
+### `parseFile(path[, options[, cb]])`
 Parses a markdown file.
 
 #### Params
-
 - **String** `path`: The file path.
-- **Object** `opts`: The parser options.
-- **Function** `cb`: The callback function.
+- **Object** `[options]`: The parser options.
+- **Function** `[cb]`: The callback function.
+
+#### Return
+- **Object** **If `cb` was omitted**: an object containing the following fields:
+ - `markdown` (String): The markdown content.
+ - `metadata` (Object): The parsed metadata.
+ - `rawMeta` (String): The raw metadata content.
+ - `html` (String): The generated HTML from markdown.
 

--- a/README.md
+++ b/README.md
@@ -74,14 +74,14 @@ There are few ways to get help:
 ## :memo: Documentation
 
 
-### `stringify(metadata, content, opts)`
+### `stringify(metadata, content[, options])`
 Stringify metadata and content.
 
 #### Params
 
 - **Object** `metadata`: The metadata object.
 - **String** `content`: The markdown content.
-- **Object** `opts`: An object containing the following fields:
+- **Object** `[options]`: An object containing the following fields:
  - `start` (String): The start delimiter of the metadata (default: `---`).
  - `end` (String): The end delimiter of the metadata (default: `---`).
  - `yamlOptions` (Object): Custom js-yaml options.
@@ -89,26 +89,22 @@ Stringify metadata and content.
 #### Return
 - **String** The markdown content prefixed by the stringified metadata.
 
-### `parse(input, opts)`
+### `parse(input[, options])`
 Parses the markdown input and the metadata.
 
 #### Params
 
 - **String** `input`: The markdown code. If it contains metadata, it will be parsed.
-- **Object** `opts`: An object containing the following fields:
+- **Object** `[options]`: An object containing the following fields:
  - `start` (String): The metadata prefix (default: `---`).
  - `end` (RegExp): The metadata end.
  - `html` (Boolean): If `true`, the markdown code will be parsed into HTML (default: `true`).
  - `converterOptions` (Object): The converter options passed to [`showdown`](https://github.com/showdownjs/showdown).
 
 #### Return
-- **Object** An object containing the following fields:
- - `markdown` (String): The markdown content.
- - `metadata` (Object): The parsed metadata.
- - `rawMeta` (String): The raw metadata content.
- - `html` (String): The generated HTML from markdown.
+- [**ParseResult**][docs-type-parseresult]
 
-### `writeFile(path, metadata, content, options, cb)`
+### `writeFile(path, metadata, content[, options[, cb]])`
 Writes the generated content into a file.
 
 #### Params
@@ -116,17 +112,30 @@ Writes the generated content into a file.
 - **String** `path`: The file path.
 - **Object** `metadata`: The metadata object.
 - **String** `content`: The markdown content.
-- **Object** `options`: The stringify options.
-- **Function** `cb`: The callback function.
+- **Object** `[options]`: The stringify options.
+- **Function** `[cb]`: The callback function.
 
-### `parseFile(path, opts, cb)`
+### `parseFile(path[, options[, cb]])`
 Parses a markdown file.
 
 #### Params
 
 - **String** `path`: The file path.
-- **Object** `opts`: The parser options.
-- **Function** `cb`: The callback function.
+- **Object** `[options]`: The parser options.
+- **Function** `[cb]`: The callback function.
+
+#### Return
+- [**ParseResult**][docs-type-parseresult] Only **if `cb` was omitted**.
+
+---
+
+### Type: `ParseResult`
+An object containing the following fields:
+
+- **String** `markdown`: The Markdown content.
+- **Object** `metadata`: The parsed metadata.
+- **String** `rawMeta`: The raw metadata content.
+- **String** `html`: The generated HTML from Markdown.
 
 
 
@@ -178,3 +187,5 @@ If you are using this library in one of your projects, add it in this list. :spa
 [website]: https://ionicabizau.net
 [contributing]: /CONTRIBUTING.md
 [docs]: /DOCUMENTATION.md
+
+[docs-type-parseresult]: #type-parseresult

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -7,13 +7,13 @@ declare class mdify {
 
     static parse(input: string, opts?: mdify.parseOptions): mdify.parseResult;
 
-    static parseFile(path: string, opts: mdify.parseOptions): mdify.parseResult;
+    static parseFile(path: string, opts?: mdify.parseOptions): mdify.parseResult;
 
-    static parseFile(path: string, opts: mdify.parseOptions, cb: (error: Error, result: mdify.parseResult) => void): void;
+    static parseFile(path: string, opts?: mdify.parseOptions, cb?: (error: Error, result: mdify.parseResult) => void): void;
 
     static stringify(metadata: any, content: string, options?: mdify.stringifyOptions): string;
 
-    static writeFile(path: string, metadata: any, content: string, options: mdify.stringifyOptions, cb: any): void;
+    static writeFile(path: string, metadata: any, content: string, options?: mdify.stringifyOptions, cb?: any): void;
 
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -63,12 +63,7 @@ module.exports = class Mdify {
      *  - `html` (Boolean): If `true`, the markdown code will be parsed into HTML (default: `true`).
      *  - `converterOptions` (Object): The converter options passed to [`showdown`](https://github.com/showdownjs/showdown).
      *
-     * @returns {Object} An object containing the following fields:
-     *
-     *  - `markdown` (String): The markdown content.
-     *  - `metadata` (Object): The parsed metadata.
-     *  - `rawMeta` (String): The raw metadata content.
-     *  - `html` (String): The generated HTML from markdown.
+     * @returns {ParseResult}
      */
     static parse (input, options) {
 
@@ -139,12 +134,7 @@ module.exports = class Mdify {
      * @param {String} path The file path.
      * @param {Object} [options] The parser options.
      * @param {Function} [cb] The callback function.
-     * @returns {Object} **If `cb` was omitted**: an object containing the following fields:
-     *
-     *  - `markdown` (String): The markdown content.
-     *  - `metadata` (Object): The parsed metadata.
-     *  - `rawMeta` (String): The raw metadata content.
-     *  - `html` (String): The generated HTML from markdown.
+     * @returns {ParseResult} Only **if `cb` was omitted**.
      */
     static parseFile (path, options, cb) {
         if (typeof options === "function") {
@@ -161,3 +151,12 @@ module.exports = class Mdify {
         }
     }
 };
+
+/**
+ * An object containing the following fields:
+ * @typedef {Object} ParseResult
+ * @property {String} markdown The Markdown content.
+ * @property {Object} metadata The parsed metadata.
+ * @property {String} rawMeta The raw metadata content.
+ * @property {String} html The generated HTML from Markdown.
+ */

--- a/lib/index.js
+++ b/lib/index.js
@@ -17,7 +17,7 @@ module.exports = class Mdify {
      * @function
      * @param {Object} metadata The metadata object.
      * @param {String} content The markdown content.
-     * @param {Object} opts An object containing the following fields:
+     * @param {Object} [options] An object containing the following fields:
      *
      *  - `start` (String): The start delimiter of the metadata (default: `---`).
      *  - `end` (String): The end delimiter of the metadata (default: `---`).
@@ -56,7 +56,7 @@ module.exports = class Mdify {
      * @name parse
      * @function
      * @param {String} input The markdown code. If it contains metadata, it will be parsed.
-     * @param {Object} opts An object containing the following fields:
+     * @param {Object} [options] An object containing the following fields:
      *
      *  - `start` (String): The metadata prefix (default: `---`).
      *  - `end` (RegExp): The metadata end.
@@ -70,9 +70,9 @@ module.exports = class Mdify {
      *  - `rawMeta` (String): The raw metadata content.
      *  - `html` (String): The generated HTML from markdown.
      */
-    static parse (input, opts) {
+    static parse (input, options) {
 
-        opts = ul.merge(opts, {
+        options = ul.merge(options, {
             start: "---"
           , end: /\n(\-{3})/g
           , html: true
@@ -86,18 +86,18 @@ module.exports = class Mdify {
           , rawMeta: null
         };
 
-        if (input.startsWith(opts.start)) {
-            let res = opts.end.exec(input);
+        if (input.startsWith(options.start)) {
+            let res = options.end.exec(input);
             if (res) {
                 result.rawMeta = input.slice(0, res.index) || "";
-                result.markdown = input.slice(opts.end.lastIndex);
+                result.markdown = input.slice(options.end.lastIndex);
                 result.metadata = yaml.safeLoad(result.rawMeta);
             }
         }
 
-        if (opts.html) {
-            opts.converter = new showdown.Converter(opts.converterOptions);
-            result.html = opts.converter.makeHtml(result.markdown);
+        if (options.html) {
+            options.converter = new showdown.Converter(options.converterOptions);
+            result.html = options.converter.makeHtml(result.markdown);
         }
 
         return result;
@@ -112,8 +112,8 @@ module.exports = class Mdify {
      * @param {String} path The file path.
      * @param {Object} metadata The metadata object.
      * @param {String} content The markdown content.
-     * @param {Object} options The stringify options.
-     * @param {Function} cb The callback function.
+     * @param {Object} [options] The stringify options.
+     * @param {Function} [cb] The callback function.
      */
     static writeFile (path, metadata, content, options, cb) {
 
@@ -137,21 +137,27 @@ module.exports = class Mdify {
      * @name parseFile
      * @function
      * @param {String} path The file path.
-     * @param {Object} opts The parser options.
-     * @param {Function} cb The callback function.
+     * @param {Object} [options] The parser options.
+     * @param {Function} [cb] The callback function.
+     * @returns {Object} **If `cb` was omitted**: an object containing the following fields:
+     *
+     *  - `markdown` (String): The markdown content.
+     *  - `metadata` (Object): The parsed metadata.
+     *  - `rawMeta` (String): The raw metadata content.
+     *  - `html` (String): The generated HTML from markdown.
      */
-    static parseFile (path, opts, cb) {
-        if (typeof opts === "function") {
-            cb = opts;
-            opts = {};
+    static parseFile (path, options, cb) {
+        if (typeof options === "function") {
+            cb = options;
+            options = {};
         }
         if (cb) {
             readFile(path, (err, data) => {
                 if (err) { return cb(err); }
-                cb(null, Mdify.parse(data, opts));
+                cb(null, Mdify.parse(data, options));
             });
         } else {
-            return Mdify.parse(readFile(path), opts);
+            return Mdify.parse(readFile(path), options);
         }
     }
 };

--- a/package.json
+++ b/package.json
@@ -46,14 +46,12 @@
   },
   "homepage": "https://github.com/IonicaBizau/mdify#readme",
   "dependencies": {
+    "@types/js-yaml": "^3.11.2",
+    "@types/showdown": "^1.7.5",
     "js-yaml": "^3.6.1",
     "read-utf8": "^1.2.3",
     "showdown": "^1.4.1",
     "ul": "^5.2.2"
-  },
-  "devDependencies": {
-    "@types/js-yaml": "^3.11.2",
-    "@types/showdown": "^1.7.5"
   },
   "blah": {
     "h_img": "http://i.imgur.com/koH6iq4.png"

--- a/package.json
+++ b/package.json
@@ -17,6 +17,11 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "Ionică Bizău <bizauionica@gmail.com> (https://ionicabizau.net)",
+  "contributors": [
+    "gazmull <vescalaw@gmail.com> (https://thegzm.space)",
+    "Fabian Iwand (https://twitter.com/mootari)",
+    "Simon Laux (https://simonlaux.de)"
+  ],
   "files": [
     "bin/",
     "app/",
@@ -41,12 +46,14 @@
   },
   "homepage": "https://github.com/IonicaBizau/mdify#readme",
   "dependencies": {
-    "@types/js-yaml": "^3.11.2",
-    "@types/showdown": "^1.7.5",
     "js-yaml": "^3.6.1",
     "read-utf8": "^1.2.3",
     "showdown": "^1.4.1",
     "ul": "^5.2.2"
+  },
+  "devDependencies": {
+    "@types/js-yaml": "^3.11.2",
+    "@types/showdown": "^1.7.5"
   },
   "blah": {
     "h_img": "http://i.imgur.com/koH6iq4.png"


### PR DESCRIPTION
### Fixes
- Inaccurate types and JSDoc for `parseFile` (It actually returns a parseResult object if `cb` was omitted)
- Inaccurate JSDoc parameters (Added `[]` to indicate they're optional)
- Inconsistent parameter name (`opts` => `options`)

Also added missing contributors in `package.json`. 😀 